### PR TITLE
Pull User Email From Redux When Submitting Order

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
1. Updates `LOGIN` case in `authReducer` to set user email from `action.payload.email` instead of non-existent `action.payload.login`

## Purpose
The client currently does not pull the user's email from Redux when submitting an order. This makes it extremely difficult for a business to fulfill an order for a given user.

## Approach
Corrected property called on `action.payload` when setting the `email` property in the store.

## Learning
With never using React or Redux before, I spent some time going over the documentation.
[React-Redux Docs](https://react-redux.js.org/api)

Closes Shift3#17