### PR TITLE
Order Form Submission Fix

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
## Changes
1. Changes property set in the `menuItemChosen` method from `item` to `order_item`

## Purpose
Users currently cannot submit their order.

## Approach
The `menuItemChosen` method was originally attempting to set a non existant state property called `item`. This was changed from `item` to `order_item` to match the existing component state declaration.

Closes Shift3#14