### PR TITLE
ViewOrders: Proper Time Formatting

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -24,8 +24,9 @@ class ViewOrders extends Component {
         return (
             <Template>
                 <div className="container-fluid">
-                    {this.state.orders.map(order => {
-                        const createdDate = new Date(order.createdAt);
+                    { // TODO: extract this to separate "order" component
+                      this.state.orders.map(order => {
+                        const createdDate = new Date(order.createdAt).toTimeString().substr(0, 8);
                         return (
                             <div className="row view-order-container" key={order._id}>
                                 <div className="col-md-4 view-order-left-col p-3">
@@ -33,7 +34,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at { createdDate }</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
## Changes
1. Changes format of the `createdDate` time string in the `render` method to include a leading 0 when necessary

## Purpose
Order Time does not zero-pad minute and seconds correctly when values are under 10

## Approach
Instead of calling several methods for each section of a given time, we call `.toTimeString()` on the `Date` object. This let JavaScript format the time for us, and we can then pull a consistent sub-string from the returned value.

Closes Shift3#30